### PR TITLE
remove axis and read elements from svg when not needed

### DIFF
--- a/genomeview/convenience.py
+++ b/genomeview/convenience.py
@@ -1414,14 +1414,17 @@ class Configuration:
         else:
             bed_config.update_bed(self.bed_annotation)
 
-        shared_static_svg = bed_config.plot_interval(bams_dict={},
-                                                     interval = interval,
-                                                     with_bed = with_bed,
-                                                     with_reads = False,
-                                                     with_coverage = False,
-                                                     add_track_label = False,
-                                                     **kwargs
-                                                    )._repr_svg__()
+        if len(bams_dict) > 1:
+            shared_static_svg = bed_config.plot_interval(bams_dict={},
+                                                        interval = interval,
+                                                        with_bed = with_bed,
+                                                        with_reads = False,
+                                                        with_coverage = False,
+                                                        add_track_label = False,
+                                                        **kwargs
+                                                        )._repr_svg__()
+        else:
+            shared_static_svg = ""
         
         tab_sections = []
         for key, bam in bams_dict.items():
@@ -1454,17 +1457,18 @@ class Configuration:
                                                  **kwargs
                                                 )._repr_svg__() + "</br>"
 
-            resizable_svg += self.plot_interval(bams_dict = {key: bam},
-                                                interval = interval,
-                                                with_reads = with_reads,
-                                                with_coverage = False,
-                                                with_axis = False,
-                                                with_bed = False,
-                                                add_track_label = False,
-                                                add_reads_label = False,
-                                                vertical_layout_reads = True,
-                                                **kwargs
-                                               )._repr_svg__() + "</br>"
+            if with_reads:
+                resizable_svg += self.plot_interval(bams_dict = {key: bam},
+                                                    interval = interval,
+                                                    with_reads = with_reads,
+                                                    with_coverage = False,
+                                                    with_axis = False,
+                                                    with_bed = False,
+                                                    add_track_label = False,
+                                                    add_reads_label = False,
+                                                    vertical_layout_reads = True,
+                                                    **kwargs
+                                                )._repr_svg__() + "</br>"
 
             tab_sections.append({
                 'unique_id': unique_id,

--- a/genomeview/convenience.py
+++ b/genomeview/convenience.py
@@ -1414,17 +1414,14 @@ class Configuration:
         else:
             bed_config.update_bed(self.bed_annotation)
 
-        if len(bams_dict) > 1:
-            shared_static_svg = bed_config.plot_interval(bams_dict={},
-                                                        interval = interval,
-                                                        with_bed = with_bed,
-                                                        with_reads = False,
-                                                        with_coverage = False,
-                                                        add_track_label = False,
-                                                        **kwargs
-                                                        )._repr_svg__()
-        else:
-            shared_static_svg = ""
+        shared_static_svg = bed_config.plot_interval(bams_dict={},
+                                                    interval = interval,
+                                                    with_bed = with_bed,
+                                                    with_reads = False,
+                                                    with_coverage = False,
+                                                    add_track_label = False,
+                                                    **kwargs
+                                                    )._repr_svg__()
         
         tab_sections = []
         for key, bam in bams_dict.items():
@@ -1450,6 +1447,7 @@ class Configuration:
                                                  interval = interval,
                                                  with_reads = False,
                                                  with_coverage = True,
+                                                 with_axis = len(bams_dict) > 1,
                                                  with_bed = False,
                                                  add_track_label = False,
                                                  fill_coverage = fill_coverage,

--- a/genomeview/templates/bam_buttons_views.html
+++ b/genomeview/templates/bam_buttons_views.html
@@ -15,8 +15,10 @@
         <div class="genomeview-content static-genomeview-content">
             {{ tab_section.static_svg | safe }}
         </div>
+        {% if tab_section.resizable_svg %}
         <div id="svgContainer" class="resizable">
             {{ tab_section.resizable_svg | safe }}
         </div>
+        {% endif %}
     </div>
 {% endfor %}


### PR DESCRIPTION
A couple small tweaks to the tabbed view:

 * If there's only one BAM, we don't need an extra genome axis at the top (we might not need it in general? But I haven't tried that yet)
 * If `with_reads=False`, we don't need the resizable svg element at all. This makes the display a lot smaller and easier to browse

Possible these changes could be ported to other views/templates, I didn't investigate that.